### PR TITLE
Removed min and target version from manifest

### DIFF
--- a/library/AndroidManifest.xml
+++ b/library/AndroidManifest.xml
@@ -4,10 +4,6 @@
     android:versionCode="1"
     android:versionName="1.0" >
 
-    <uses-sdk
-        android:minSdkVersion="14"
-        android:targetSdkVersion="19" />
-
     <application />
 
 </manifest>


### PR DESCRIPTION
We don't need to set min and target version here as it is already defined in the [build.gradle](https://github.com/guerwan/TransitionsBackport/blob/master/library/build.gradle#L20-L21).
Plus it should fix 

```
Execution failed for task ':MyApp:processDebugManifest'.
> Manifest merging failed. See console for more info.
Main manifest has <uses-sdk android:minSdkVersion='10'> but library uses minSdkVersion='14'
```
